### PR TITLE
Implement global store management

### DIFF
--- a/playground/main-anton.js
+++ b/playground/main-anton.js
@@ -1,10 +1,14 @@
 import '@styles/main.scss';
 import { createElement } from '@utils/dom';
+import { appStore } from '@stores/app-store';
 
 const App = () => {
   const container = createElement({ tag: 'div', className: 'container' });
   const title = createElement({ tag: 'p', textContent: 'Anton' });
   container.appendChild(title);
+
+  // Display app state
+  console.log(appStore.getState());
 
   return container;
 };

--- a/src/stores/app-store.js
+++ b/src/stores/app-store.js
@@ -1,0 +1,39 @@
+import dayjs from 'dayjs';
+import { createPersistentStore } from '@stores/persistent-store';
+import { generateUniqueId } from '@utils/nanoid';
+
+const STORAGE_KEY = 'tms-trello-state';
+
+const DEFAULT_BOARD = {
+  id: generateUniqueId(),
+  name: 'Team Project Board',
+  background: 'url-to-image.jpg',
+};
+
+const DEFAULT_LIST_TITLES = ['Todo', 'In Progress', 'Done'];
+const DEFAULT_LISTS = DEFAULT_LIST_TITLES.map((name) => {
+  return {
+    id: generateUniqueId(),
+    boardId: DEFAULT_BOARD.id,
+    name: name,
+    color: 'cool-gray',
+  };
+});
+
+const DEFAULT_APP_STATE = {
+  board: DEFAULT_BOARD,
+  lists: DEFAULT_LISTS,
+  cards: [
+    {
+      id: generateUniqueId(),
+      listId: DEFAULT_LISTS[0].id,
+      title: 'Implement drag & drop for the card component',
+      description:
+        'Users should be able to drag and reorder task cards within the same column, with changes reflected in both the UI and backend.',
+      assignee: 'Clementine Bauch',
+      createdAt: dayjs().toISOString(),
+    },
+  ],
+};
+
+export const appStore = createPersistentStore({ key: STORAGE_KEY, initialState: DEFAULT_APP_STATE });

--- a/src/stores/cards-store.js
+++ b/src/stores/cards-store.js
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs';
+import { generateUniqueId } from '@utils/nanoid';
+import { appStore } from '@stores/app-store';
+
+export const cardsStore = {
+  // Get all cards
+  getCards: () => appStore.getState().cards,
+
+  // Add a card
+  addCard: ({ listId, title, description, assignee }) => {
+    const card = {
+      id: generateUniqueId(),
+      listId,
+      title,
+      description,
+      assignee,
+      createdAt: dayjs().toISOString(),
+    };
+    appStore.setState({ cards: [...appStore.getState().cards, card] });
+  },
+
+  // Update card { title, description, assignee }
+  updateCard: (id, updates) => {
+    appStore.setState({
+      cards: appStore.getState().cards.map((card) => (card.id === id ? { ...card, ...updates } : card)),
+    });
+  },
+
+  // Remove card
+  removeCard: (id) => {
+    appStore.setState({ cards: appStore.getState().cards.filter((card) => card.id !== id) });
+  },
+
+  // Remove all cards by list name
+  removeCardsByListName: (listName) => {
+    const list = appStore.getState().lists.find((list) => list.name === listName);
+    if (!list) return;
+    appStore.setState({ cards: appStore.getState().cards.filter((card) => card.listId !== list.id) });
+  },
+
+  // Remove all cards
+  removeAllCards: () => {
+    appStore.setState({ cards: [] });
+  },
+};

--- a/src/stores/list-store.js
+++ b/src/stores/list-store.js
@@ -1,0 +1,29 @@
+import { appStore } from '@stores/app-store';
+import { generateUniqueId } from '@utils/nanoid';
+
+export const listStore = {
+  // Get all lists
+  getLists: () => appStore.getState().lists,
+
+  // Add list
+  addList: ({ name, color }) => {
+    const list = {
+      id: generateUniqueId(),
+      name,
+      color,
+    };
+    appStore.setState({ lists: [...appStore.getState().lists, list] });
+  },
+
+  // Update list { name, color }
+  updateList: (id, updates) => {
+    appStore.setState({
+      lists: appStore.getState().lists.map((list) => (list.id === id ? { ...list, ...updates } : list)),
+    });
+  },
+
+  // Remove list by id
+  removeList: (id) => {
+    appStore.setState({ lists: appStore.getState().lists.filter((list) => list.id !== id) });
+  },
+};

--- a/src/stores/persistent-store.js
+++ b/src/stores/persistent-store.js
@@ -1,0 +1,19 @@
+// This is a generic store that can be used to store any state in localStorage
+export const createPersistentStore = ({ key, initialState }) => {
+  const savedState = localStorage.getItem(key);
+  let state = savedState ? JSON.parse(savedState) : { ...initialState };
+  localStorage.setItem(key, JSON.stringify(state));
+
+  const save = () => {
+    localStorage.setItem(key, JSON.stringify(state));
+  };
+
+  const getState = () => ({ ...state });
+
+  const setState = (newState) => {
+    state = { ...state, ...newState };
+    save();
+  };
+
+  return { getState, setState };
+};

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,5 +1,5 @@
 // Create DOM element
-export const createElement = ({ tag, className, textContent, attributes = {}, dataset = {} }) => {
+export const createElement = ({ tag, className, textContent, attributes = {}, dataset = {}, children = [] }) => {
   const element = document.createElement(tag);
 
   if (className) element.className = className;
@@ -14,6 +14,14 @@ export const createElement = ({ tag, className, textContent, attributes = {}, da
   if (dataset) {
     Object.entries(dataset).forEach(([key, value]) => {
       element.dataset[key] = value ?? '';
+    });
+  }
+
+  if (Array.isArray(children)) {
+    children.forEach((child) => {
+      if (child instanceof Node) {
+        element.appendChild(child);
+      }
     });
   }
 

--- a/src/utils/nanoid.js
+++ b/src/utils/nanoid.js
@@ -1,0 +1,7 @@
+import { customAlphabet } from 'nanoid';
+
+// Custom ID format generation
+const nanoid8 = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 8);
+
+// Generate a unique 8-character ID
+export const generateUniqueId = () => nanoid8();


### PR DESCRIPTION
- Add persistent store
- Implement  app, board, lists, cards store management
- Add children parameter to createElement function
- Add 8-digits nanoid generator

To use store inside your playground:
```
import { appStore } from '@stores/app-store';

const board = appStore.getState().board
const lists = appStore.getState().lists
const cards = appStore.getState().cards
```